### PR TITLE
Use Jawn JSON parser in order to avoid using the DSL when not needed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ lazy val diesel = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.ibm.cloud.diesel" %%% "diesel-i18n"     % Dependencies.dieselI18nVersion,
       "com.ibm.cloud.diesel" %%% "diesel-core"     % Dependencies.dieselVersion,
-      "io.github.cquiroz"    %%% "scala-java-time" % "2.6.0"
+      "io.github.cquiroz"    %%% "scala-java-time" % "2.6.0",
+      "org.typelevel"        %%% "jawn-parser"     % "1.3.2"
     )
   )
   .settings(

--- a/diesel/shared/src/main/scala/diesel/json/JsonParser.scala
+++ b/diesel/shared/src/main/scala/diesel/json/JsonParser.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package diesel.json
 
 import org.typelevel.jawn

--- a/diesel/shared/src/main/scala/diesel/json/JsonParser.scala
+++ b/diesel/shared/src/main/scala/diesel/json/JsonParser.scala
@@ -1,0 +1,91 @@
+package diesel.json
+
+import org.typelevel.jawn
+import diesel.json.Ast.Position
+import scala.util.Failure
+import scala.util.Success
+
+object JsonParser {
+
+  private object Facade extends jawn.Facade[Ast.Value] {
+
+    override def singleContext(index: Int): jawn.FContext[Ast.Value] = new jawn.FContext[Ast.Value]() {
+      private var current: Option[Ast.Value]              = None
+      override def add(s: CharSequence, index: Int): Unit = {
+        val str = s.toString()
+        current = Some(Ast.Str(Position(index, s.length() + 2), str))
+      }
+      override def add(v: Ast.Value, index: Int): Unit    =
+        current = Some(v)
+      override def finish(index: Int): Ast.Value          =
+        current.getOrElse(throw new IllegalStateException("missing single value"))
+      override def isObj: Boolean                         = false
+    }
+
+    override def arrayContext(startIndex: Int): jawn.FContext[Ast.Value] = new jawn.FContext[Ast.Value]() {
+      private var vs: Seq[Ast.Value] = Seq.empty
+
+      override def add(s: CharSequence, index: Int): Unit =
+        vs = vs :+ Ast.Str(Position(index, s.length() + 2), s.toString())
+      override def add(v: Ast.Value, index: Int): Unit    =
+        vs = vs :+ v
+      override def finish(index: Int): Ast.Value          =
+        Ast.Array(Position(startIndex, index - startIndex + 1), vs)
+
+      override def isObj: Boolean = false
+    }
+
+    override def objectContext(startIndex: Int): jawn.FContext[Ast.Value] = new jawn.FContext[Ast.Value]() {
+      private var currentKey: Option[Ast.AttrName]        = None
+      private var attributes: Seq[Ast.Attribute]          = Seq()
+      override def add(s: CharSequence, index: Int): Unit =
+        if (currentKey.isEmpty) {
+          currentKey = Some(Ast.AttrName(Position(index, s.length() + 2), s.toString()))
+        } else {
+          val an = currentKey.get
+          attributes = attributes :+ Ast.Attribute(
+            Position(an.position.offset, (index + s.length()) - an.position.offset + 2),
+            name = an,
+            value = Ast.Str(Position(index, s.length() + 2), s.toString())
+          )
+          currentKey = None
+        }
+      override def add(v: Ast.Value, index: Int): Unit    =
+        if (currentKey.isDefined) {
+          val an = currentKey.get
+          attributes = attributes :+ Ast.Attribute(
+            Position(an.position.offset, (v.position.offset + v.position.length) - an.position.offset),
+            an,
+            v
+          )
+          currentKey = None
+        }
+      override def finish(index: Int): Ast.Value          =
+        Ast.Object(Position(startIndex, index - startIndex + 1), attributes)
+      override def isObj: Boolean                         = true
+    }
+
+    override def jnull(index: Int): Ast.Value = Ast.Null(Position(index, "null".length))
+
+    override def jfalse(index: Int): Ast.Value = Ast.Bool(Position(index, "false".length), false)
+
+    override def jtrue(index: Int): Ast.Value = Ast.Bool(Position(index, "true".length), true)
+
+    override def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Ast.Value =
+      Ast.Number(Position(index, s.length()), s.toString)
+
+    override def jstring(s: CharSequence, index: Int): Ast.Value = Ast.Str(Position(index, s.length()), s.toString)
+
+  }
+
+  sealed trait JsonParseResult
+  case class JPRError(message: String)    extends JsonParseResult
+  case class JPRSuccess(value: Ast.Value) extends JsonParseResult
+
+  def parse(text: String): JsonParseResult = jawn.Parser.parseFromString(text)(Facade) match {
+    case Failure(exception) =>
+      JPRError(exception.getMessage())
+    case Success(value)     =>
+      JPRSuccess(value)
+  }
+}

--- a/diesel/shared/src/main/scala/diesel/json/jsonschema/Examples.scala
+++ b/diesel/shared/src/main/scala/diesel/json/jsonschema/Examples.scala
@@ -309,7 +309,7 @@ object Examples {
       |            "radius": {
       |              "type": "number"
       |            }
-      |          }
+      |          },
       |          "required": [ "radius" ]
       |        }
       |      ]

--- a/diesel/shared/src/test/scala/diesel/json/JsonCustomPredictionTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/JsonCustomPredictionTest.scala
@@ -57,7 +57,12 @@ class JsonCustomPredictionTest extends FunSuite {
     expectedPredictions: Seq[String],
     expectedReplacements: Option[Seq[Option[(Int, Int)]]] = None
   ): Unit = {
-    val s         = JsonSchema.parse(schema).toOption.get._2
+    val s         = JsonSchema.parse(schema) match {
+      case Left(err)    =>
+        fail(err)
+      case Right(value) =>
+        value._2
+    }
     val config    = JsonCompletion.completionConfiguration(s)
     val proposals = predict(Json, text, offset, Some(config))
     assertEquals(proposals.map(_.text), expectedPredictions)
@@ -596,13 +601,13 @@ class JsonCustomPredictionTest extends FunSuite {
         |      "type": "object",
         |      "properties": {
         |        "foo": {
-        |          "type": "string",
-        |        },
-        |      },
+        |          "type": "string"
+        |        }
+        |      }
         |}""".stripMargin,
       "{}",
       offset = 1,
-      Seq("}", "\"\"", "\"foo\"", "\"\"")
+      Seq("}", "\"foo\"", "\"\"")
     )
   }
 }

--- a/diesel/shared/src/test/scala/diesel/json/JsonParserTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/JsonParserTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package diesel.json
 
 import munit.FunSuite

--- a/diesel/shared/src/test/scala/diesel/json/JsonParserTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/JsonParserTest.scala
@@ -1,0 +1,173 @@
+package diesel.json
+
+import munit.FunSuite
+import diesel.json.JsonParser.JPRError
+import diesel.json.JsonParser.JPRSuccess
+import diesel.json.Ast.Str
+import diesel.json.Ast.Position
+import diesel.json.Ast.Bool
+
+class JsonParserTest extends FunSuite {
+
+  private def doTest(text: String, expected: Ast.Value): Unit = {
+    JsonParser.parse(text) match {
+      case JPRError(message) =>
+        fail(message)
+      case JPRSuccess(value) =>
+        println(value)
+        assertEquals(value, expected)
+        Json.parseWithDsl(text) match {
+          case Left(message)   =>
+            fail(message)
+          case Right(valueDsl) =>
+            assertEquals(value, valueDsl._2)
+        }
+    }
+  }
+
+  test("string") {
+    val text = "\"yalla\""
+    doTest(text, Str(Position(0, text.length()), "yalla"))
+  }
+
+  test("number") {
+    val text = "123"
+    doTest(text, Ast.Number(Position(0, text.length()), "123"))
+  }
+
+  test("boolean true") {
+    val text = "true"
+    doTest(text, Bool(Position(0, text.length()), true))
+  }
+
+  test("boolean false") {
+    val text = "false"
+    doTest(text, Bool(Position(0, text.length()), false))
+  }
+
+  test("null") {
+    val text = "null"
+    doTest(text, Ast.Null(Position(0, text.length())))
+  }
+
+  test("array") {
+    val text = "[1,2]"
+    doTest(
+      text,
+      Ast.Array(
+        position = Position(
+          offset = 0,
+          length = 5
+        ),
+        elems = List(
+          Ast.Number(
+            position = Position(
+              offset = 1,
+              length = 1
+            ),
+            v = "1"
+          ),
+          Ast.Number(
+            position = Position(
+              offset = 3,
+              length = 1
+            ),
+            v = "2"
+          )
+        )
+      )
+    )
+  }
+
+  test("object") {
+    val text = """{"foo":123}"""
+    doTest(
+      text,
+      Ast.Object(
+        position = Position(
+          offset = 0,
+          length = 11
+        ),
+        attributes = List(
+          Ast.Attribute(
+            position = Position(
+              offset = 1,
+              length = 9
+            ),
+            name = Ast.AttrName(
+              position = Position(
+                offset = 1,
+                length = 5
+              ),
+              s = "foo"
+            ),
+            value = Ast.Number(
+              position = Position(
+                offset = 7,
+                length = 3
+              ),
+              v = "123"
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("object with str prop") {
+    val text = """{"foo":"bar"}"""
+    doTest(
+      text,
+      Ast.Object(
+        position = Position(
+          offset = 0,
+          length = 13
+        ),
+        attributes = List(
+          Ast.Attribute(
+            position = Position(
+              offset = 1,
+              length = 11
+            ),
+            name = Ast.AttrName(
+              position = Position(
+                offset = 1,
+                length = 5
+              ),
+              s = "foo"
+            ),
+            value = Ast.Str(
+              position = Position(
+                offset = 7,
+                length = 5
+              ),
+              v = "bar"
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("string array") {
+    doTest(
+      """["foo"]""",
+      Ast.Array(
+        position = Position(
+          offset = 0,
+          length = 7
+        ),
+        elems = List(
+          Str(
+            position = Position(
+              offset = 1,
+              length = 5
+            ),
+            v = "foo"
+          )
+        )
+      )
+    )
+  }
+
+}

--- a/diesel/shared/src/test/scala/diesel/json/JsonValidatorTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/JsonValidatorTest.scala
@@ -28,14 +28,14 @@ class JsonValidatorTest extends FunSuite {
   implicit val en: Messages.KeyResolver = I18n.currentKeyResolver
 
   private def validate(schema: Option[JsonSchema], text: String): Seq[Marker] = {
-    Json.parse(text) match {
-      case Json.JPRError(message)   =>
+    Json.parseWithDsl(text) match {
+      case Left(message) =>
         fail(message)
-      case Json.JPRSuccess(tree, _) =>
+      case Right(value)  =>
         val schemaMarkers = schema
-          .map(s => JsonSchema.postProcessMarkers(s)(tree))
+          .map(s => JsonSchema.postProcessMarkers(s)(value._2))
           .getOrElse(Seq.empty)
-        tree.markers ++ schemaMarkers
+        value._1.markers ++ schemaMarkers
     }
   }
 
@@ -49,7 +49,7 @@ class JsonValidatorTest extends FunSuite {
       }
     }
     val actual = validate(s, text)
-    assert(actual == expectedMarkers)
+    assertEquals(actual, expectedMarkers)
   }
 
   private def parseSchema(text: String): JsonSchema =

--- a/diesel/shared/src/test/scala/diesel/json/jsonschema/JsonSchemaProposeTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/jsonschema/JsonSchemaProposeTest.scala
@@ -16,12 +16,13 @@
 
 package diesel.json.jsonschema
 
-import diesel.json.{Ast, Json}
+import diesel.json.Ast
 import diesel.json.Ast.Constants._
 import diesel.json.Ast.Builder._
 import diesel.json.Ast.Builder.Implicits._
 import JPath.Implicits._
 import munit.FunSuite
+import diesel.json.Json
 
 class JsonSchemaProposeTest extends FunSuite {
 
@@ -43,11 +44,11 @@ class JsonSchemaProposeTest extends FunSuite {
     maxDepth: Int = -1
   ): Unit = {
     val s         = JsonSchema.parse(schema).toOption.get
-    val j         = Json.parse(json) match {
-      case Json.JPRError(message)    =>
+    val j         = Json.parseWithDsl(json) match {
+      case Left(message) =>
         fail(message)
-      case Json.JPRSuccess(_, value) =>
-        value
+      case Right(value)  =>
+        value._2
     }
     val vr        = s._2.validate(j)
     val proposals = JsonSchema.propose(vr, j, path, maxDepth)

--- a/diesel/shared/src/test/scala/diesel/json/jsonschema/JsonSchemaValidationTest.scala
+++ b/diesel/shared/src/test/scala/diesel/json/jsonschema/JsonSchemaValidationTest.scala
@@ -53,7 +53,7 @@ class JsonSchemaValidationTest extends FunSuite {
   }
 
   private def assertErrors(schema: String)(json: String, expected: Any): Unit =
-    Util.assertErrors(parseSchema(schema))(json) { (_, e) => assert(e == expected) }
+    Util.assertErrors(parseSchema(schema))(json) { (_, e) => assertEquals(e, expected) }
 
   private def assertNoErrors(schema: String)(json: String): Unit =
     Util.assertErrors(parseSchema(schema))(json) { (_, e) => assert(e.isEmpty) }
@@ -490,8 +490,8 @@ class JsonSchemaValidationTest extends FunSuite {
   private val schemaPattern: String =
     """{
       |  "type": "string",
-      |  "pattern": "\d+"
-      |""".stripMargin
+      |  "pattern": "\\d+"
+      |}""".stripMargin
 
   test("pattern ok") {
     assertErrors(schemaPattern)(

--- a/diesel/shared/src/test/scala/diesel/json/jsonschema/Util.scala
+++ b/diesel/shared/src/test/scala/diesel/json/jsonschema/Util.scala
@@ -24,7 +24,7 @@ object Util {
 
   def parseSchema(text: String, externalResourceResolver: Option[String => Option[String]] = None): JsonSchema =
     JsonParser.parse(text) match {
-      case JsonParser.JPRError(message)    =>
+      case JsonParser.JPRError(message) =>
         fail(s"Unable to parse schema : $message")
       case JsonParser.JPRSuccess(value) =>
         parseSchemaValue(value, externalResourceResolver)
@@ -38,7 +38,7 @@ object Util {
 
   def parseJson(text: String): Ast.Value =
     JsonParser.parse(text) match {
-      case JsonParser.JPRError(message)       =>
+      case JsonParser.JPRError(message) =>
         fail(message)
       case JsonParser.JPRSuccess(value) =>
         value

--- a/diesel/shared/src/test/scala/diesel/json/jsonschema/Util.scala
+++ b/diesel/shared/src/test/scala/diesel/json/jsonschema/Util.scala
@@ -16,16 +16,17 @@
 
 package diesel.json.jsonschema
 
-import diesel.json.{Ast, Json}
+import diesel.json.Ast
 import munit.Assertions.fail
+import diesel.json.JsonParser
 
 object Util {
 
   def parseSchema(text: String, externalResourceResolver: Option[String => Option[String]] = None): JsonSchema =
-    Json.parse(text) match {
-      case Json.JPRError(message)    =>
+    JsonParser.parse(text) match {
+      case JsonParser.JPRError(message)    =>
         fail(s"Unable to parse schema : $message")
-      case Json.JPRSuccess(_, value) =>
+      case JsonParser.JPRSuccess(value) =>
         parseSchemaValue(value, externalResourceResolver)
     }
 
@@ -36,10 +37,10 @@ object Util {
     JsonSchema.parse(value, new JsonSchemaParserContext(value, externalResourceResolver))
 
   def parseJson(text: String): Ast.Value =
-    Json.parse(text) match {
-      case Json.JPRError(message)       =>
+    JsonParser.parse(text) match {
+      case JsonParser.JPRError(message)       =>
         fail(message)
-      case Json.JPRSuccess(tree, value) =>
+      case JsonParser.JPRSuccess(value) =>
         value
     }
 

--- a/js-facade/src/main/scala/diesel/json/jsonschema/facade/JsonSchemaJsFacade.scala
+++ b/js-facade/src/main/scala/diesel/json/jsonschema/facade/JsonSchemaJsFacade.scala
@@ -26,6 +26,8 @@ import diesel.{CompletionConfiguration, GenericTree, Marker}
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.annotation.{JSExport, JSExportAll, JSExportTopLevel}
+import diesel.json.Ast
+import diesel.json.JsonParser
 
 @JSExportTopLevel("JsonSchemaJsFacade")
 object JsonSchemaJsFacade {
@@ -34,7 +36,7 @@ object JsonSchemaJsFacade {
     override def postProcessMarkers(tree: GenericTree): Seq[Marker] = {
       val existingMarkers = tree.markers
       println("existing", existingMarkers)
-      val schemaMarkers   = JsonSchema.postProcessMarkers(schema)(tree)
+      val schemaMarkers   = JsonSchema.postProcessMarkers(schema)(tree.value.asInstanceOf[Ast.Value])
       println("schema", schemaMarkers)
       existingMarkers ++ schemaMarkers
     }
@@ -92,9 +94,9 @@ object JsonSchemaJsFacade {
 
   @JSExport
   def parseValue(value: String): JsonValue = {
-    Json.parse(value) match {
-      case Json.JPRError(err)    => throw new RuntimeException(err)
-      case Json.JPRSuccess(_, v) => JsonValue(v.clearPosition)
+    JsonParser.parse(value) match {
+      case JsonParser.JPRError(err) => throw new RuntimeException(err)
+      case JsonParser.JPRSuccess(v) => JsonValue(v.clearPosition)
     }
   }
 

--- a/js-facade/src/test/scala/diesel/json/jsonschema/JsonSchemaJsFacadeTest.scala
+++ b/js-facade/src/test/scala/diesel/json/jsonschema/JsonSchemaJsFacadeTest.scala
@@ -275,9 +275,9 @@ class JsonSchemaJsFacadeTest extends FunSuite {
                                                  |      "type": "object",
                                                  |      "properties": {
                                                  |        "foo": {
-                                                 |          "type": "string",
-                                                 |        },
-                                                 |      },
+                                                 |          "type": "string"
+                                                 |        }
+                                                 |      }
                                                  |}""".stripMargin)
     val parser = JsonSchemaJsFacade.getJsonParser(schema)
     val res    = parser.predict(js.Dynamic.literal(
@@ -287,7 +287,7 @@ class JsonSchemaJsFacadeTest extends FunSuite {
     assertEquals(res.error, js.undefined)
     assertEquals(
       res.proposals.map(_.text).toSeq,
-      Seq("}", "\"\"", "\"foo\"")
+      Seq("}", "\"foo\"", "\"\"")
     )
   }
 


### PR DESCRIPTION
Use Jawn parser for schema parsing, keep Earley only for DSL related stuff.